### PR TITLE
Feature/password reset

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,22 @@
 <h2><%= t('.change_your_password') %></h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <%= f.label :password, t('.new_password') %><br />
-    <% if @minimum_password_length %>
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, t('.confirm_new_password') %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit t('.change_my_password') %>
-  </div>
-<% end %>
-
+<div class="mx-auto p-3 mt-4 shadow rounded">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
+    <div class="field">
+      <%= f.label :password, t('.new_password') %><br />
+      <% if @minimum_password_length %>
+        <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br />
+      <% end %>
+      <%= f.password_field :password, autofocus: true, class: "w-100", autocomplete: "new-password" %>
+    </div>
+    <div class="field">
+      <%= f.label :password_confirmation, t('.confirm_new_password') %><br />
+      <%= f.password_field :password_confirmation, class: "w-100", autocomplete: "new-password" %>
+    </div>
+    <div class="actions">
+      <%= f.submit t('.change_my_password') %>
+    </div>
+  <% end %>
+</div>
 <%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,20 @@
 <h2><%= t('.forgot_your_password') %></h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="mx-auto p-3 mt-4 shadow rounded">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <div class="field p-2">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, class: "w-100", autofocus: true, autocomplete: "email" %>
+    </div>
+    <div class="actions p-2">
+      <%= f.submit t('.send_me_reset_password_instructions'), class: "btn btn-success" %>
+    </div>
+  <% end %>
+  <div class="mt-5">
+    <p class="mx-auto"><%= link_to "ゲストログインでお試ししてみる", users_guest_sign_in_path, class: "btn btn-paper bg-paper" %></p>
+    <%= link_to user_google_oauth2_omniauth_authorize_path do %>
+      <%= image_tag "btn_google_signin_light_normal_web.png", class: "d-block mx-auto" %>
+    <% end %>
   </div>
 
-  <div class="actions">
-    <%= f.submit t('.send_me_reset_password_instructions') %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -25,6 +25,6 @@
     <%= link_to user_google_oauth2_omniauth_authorize_path do %>
       <%= image_tag "btn_google_signin_light_normal_web.png", class: "d-block mx-auto" %>
     <% end %>
+    <%= link_to "パスワードをお忘れですか？", new_user_password_path %>
   </div>
 </div>
-

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,13 +119,16 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   config.action_mailer.raise_delivery_errors = true
-  ActionMailer::Base.delivery_method = :smtp
+
+  config.action_mailer.delivery_method = :smtp
+  host = 'https://papeterie-station-7e4731a83553.herokuapp.com/'
+  config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
     :port           => ENV['MAILGUN_SMTP_PORT'],
     :address        => ENV['MAILGUN_SMTP_SERVER'],
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-    :domain         => 'papeterie-station-7e4731a83553.herokuapp.com',
+    :domain         => host,
     :authentication => :plain,
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,15 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.action_mailer.raise_delivery_errors = true
+  ActionMailer::Base.delivery_method = :smtp
+  ActionMailer::Base.smtp_settings = {
+    :port           => ENV['MAILGUN_SMTP_PORT'],
+    :address        => ENV['MAILGUN_SMTP_SERVER'],
+    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+    :domain         => 'papeterie-station-7e4731a83553.herokuapp.com',
+    :authentication => :plain,
+  }
 end


### PR DESCRIPTION
## 概要
パスワードリセットメールを送信できるようにします。

## 変更点
- mailgunの設定
- config/enviroment/production.rbにmailgunの設定を追加
- ログインページにパスワードリセットページにアクセスするリンクを追加
- viewファイルの編集

## 動作確認
私用のメールアドレスをmailgunで認証後、パスワードリセットメールを送信した。

## その他
- mailgunの無料プランについて
無料プランだと、認証済みのメールアドレス以外には送ることはできない。
認証済みの私用メールアドレスにメールが届いたのは確認できたが、
他のユーザーにパスワードリセットメールを送るには有料プランに変更する必要がある。
